### PR TITLE
refactor: Remove waitGroups

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func run() error {
 		return fmt.Errorf("error copying output string to clipboard: %w", err)
 	}
 
+  fmt.Print("\r")
 	fmt.Print(
 		"\nSuccess ✅\n",
 		links,
@@ -46,7 +47,6 @@ func showLoadingIndicator() chan bool {
 		for {
 			select {
 			case <-stopLoading:
-				fmt.Print("\r")
 				return
 			default:
 				fmt.Printf("\rLoading %s", chars[i])

--- a/main.go
+++ b/main.go
@@ -8,27 +8,33 @@ import (
 )
 
 func main() {
-	err := run()
-	if err != nil {
+	err := run(); if err != nil {
 		fmt.Println("An error occurred:", err)
 	}
 }
 
 func run() error {
-	searchURL, err := clipboard.ReadAll()
-	if err != nil {
+	searchURL, err := clipboard.ReadAll(); if err != nil {
 		return fmt.Errorf("error reading clipboard: %w", err)
 	}
 
 	stopLoading := showLoadingIndicator()
 
-	err = GetLinks(searchURL)
-	if err != nil {
+	links, err := GetLinks(searchURL); if err != nil {
 		return fmt.Errorf("error getting links: %w", err)
 	}
-
+  
 	stopLoading <- true
 
+	err = clipboard.WriteAll(links); if err != nil {
+		return fmt.Errorf("error copying output string to clipboard: %w", err)
+	}
+
+	fmt.Print(
+		"\nSuccess ✅\n",
+		links,
+		"\nCopied to the clipboard\n\n",
+	)  
 	return nil
 }
 

--- a/songlinkfetcher.go
+++ b/songlinkfetcher.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-
-	"github.com/atotto/clipboard"
 )
 
 type SonglinkResponse struct {
@@ -23,10 +21,9 @@ type PlatformMusic struct {
 	URL string `json:"url"`
 }
 
-func GetLinks(searchURL string) error {
-	response, err := makeRequest(searchURL)
-	if err != nil {
-		return err
+func GetLinks(searchURL string) (string, error) {
+	response, err := makeRequest(searchURL); if err != nil {
+		return "", err
 	}
 
 	platform := PlatformMusic{
@@ -41,9 +38,8 @@ func GetLinks(searchURL string) error {
 	}
 
 	decoder := json.NewDecoder(response.Body)
-	err = decoder.Decode(&linksResponse)
-	if err != nil {
-		return fmt.Errorf("error decoding JSON response: %w", err)
+	err = decoder.Decode(&linksResponse); if err != nil {
+		return "", fmt.Errorf("error decoding JSON response: %w", err)
 	}
 
 	nonLocalURL := strings.ReplaceAll(linksResponse.PageURL, "/fi", "")
@@ -53,25 +49,12 @@ func GetLinks(searchURL string) error {
 	if nonLocalURL != "" && spotifyURL != "" {
 		outputString = fmt.Sprintf("<%s>\n%s", nonLocalURL, spotifyURL)
 	}
-
-	err = clipboard.WriteAll(outputString)
-	if err != nil {
-		return fmt.Errorf("error copying output string to clipboard: %w", err)
-	}
-
-	fmt.Print(
-		"\nSuccess ✅\n",
-		outputString,
-		"\nCopied to the clipboard\n\n",
-	)
-
-	return nil
+	return outputString, nil
 }
 
 func makeRequest(searchURL string) (*http.Response, error) {
 	url := buildURL(searchURL)
-	response, err := http.Get(url)
-	if err != nil {
+	response, err := http.Get(url); if err != nil {
 		return nil, fmt.Errorf("error making HTTP request: %w", err)
 	}
 


### PR DESCRIPTION
So, I tried refactoring to remove the use of `WaitGroups` and the code is compiling but couldn't test it coz the changes are in `main.go`. Let me know if it works. It should work theoretically.

commit [74965cc](https://github.com/marcusziade/songlink-cli/pull/10/commits/74965ccebc2e8ce5c35434d956c01ac15d43c9d1):  
- No need to use WaitGroups as we are using a `stopLoading` channel and GetLinks is synchronous.

commit [8b3c5cf](https://github.com/marcusziade/songlink-cli/pull/10/commits/8b3c5cf4a24953378b504dc1cb1b3682a4cc78bf):  
- GetLinks shouldn't be responsible for clipboard actions and printing on terminal.
- As we usually handle error case in go first, we can do that on the same line as the function call to remove the visual clutter of repeated use of `err !=`.  

commit [70adfb8](https://github.com/marcusziade/songlink-cli/pull/10/commits/70adfb8c27fe6615c42fb64f96335ce484229052):  
- Cursor can be reset before printing to make it more correct, as cursor might not be reset before run function prints the links as there are two threads of execution.