### PR TITLE
update GITHUB_TOKEN to use PAT in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
This pull request includes changes to the release workflow and the `goreleaser` configuration. The most important changes involve updating the GitHub token used for authentication and disabling the signing of checksum files.

Workflow updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L48-R48): Updated the `GITHUB_TOKEN` environment variable to use the `secrets.PAT` instead of `secrets.GITHUB_TOKEN` for authentication.

Configuration changes:

* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L61-R63): Disabled the signing of checksum files due to the lack of GPG keys configured in the CI environment.